### PR TITLE
Placeholder grayscale refract cloak material

### DIFF
--- a/neo/materials/models/player/toc.vmt
+++ b/neo/materials/models/player/toc.vmt
@@ -20,7 +20,7 @@
 	"$one" 1
 	"$two" 2
 	"$blurstart" .2
-	"$mod" .8
+	//"$mod" .8
 	"$modtwo" .6
 	
 	"$alpha" 255
@@ -42,12 +42,12 @@
 			"srcvar1"	"$thermoptic"
 			"resultvar"	"$refractamount"
 		}
-		"Multiply"
-		{
-			"srcvar1"	"$mod"
-			"srcvar2"	"$thermoptic"
-			"resultvar"	"$temp"
-		}
+		//"Multiply"
+		//{
+		//	"srcvar1"	"$mod"
+		//	"srcvar2"	"$thermoptic"
+		//	"resultvar"	"$temp"
+		//}
 		"Multiply"
 		{
 			"srcvar1"	"$modtwo"

--- a/neo/materials/models/player/toc.vmt
+++ b/neo/materials/models/player/toc.vmt
@@ -1,0 +1,88 @@
+"Refract"
+{
+	"$model" 1
+	"$refractamount" "0.2"
+	"$refracttint" "[1.0 1.0 1.0]"
+	"$translucent" 1
+	"$forcerefract" 1
+	"$vertexalpha" "1"
+	"$vertexcolor" "1"
+	"$bluramount" "1.6"		
+
+	"$dudvmap" "dev/water_dudv"
+	"$normalmap" "dev/water_normal"
+
+	"$surfaceprop" "water"
+	"$bumpframe" "0"
+	
+	"$thermoptic" 0
+	"$temp" 0
+	"$one" 1
+	"$two" 2
+	"$blurstart" .2
+	"$mod" .8
+	"$modtwo" .6
+	
+	"$alpha" 255
+
+	"Proxies"
+	{
+		"TextureScroll"
+		{
+			"texturescrollvar" "$bumptransform"
+			"texturescrollrate" .05
+			"texturescrollangle" 45.00
+		}
+		"PlayerTO"
+		{
+			"resultvar" "$thermoptic"
+		}
+		"Equals"
+		{
+			"srcvar1"	"$thermoptic"
+			"resultvar"	"$refractamount"
+		}
+		"Multiply"
+		{
+			"srcvar1"	"$mod"
+			"srcvar2"	"$thermoptic"
+			"resultvar"	"$temp"
+		}
+		"Multiply"
+		{
+			"srcvar1"	"$modtwo"
+			"srcvar2"	"$thermoptic"
+			"resultvar"	"$temp"
+		}	
+		"Subtract"
+		{
+			"srcvar1"	"$one"
+			"srcvar2"	"$temp"
+			"resultvar"	"$refracttint[0]"
+		}	
+		"Subtract"
+		{
+			"srcvar1"	"$one"
+			"srcvar2"	"$temp"
+			"resultvar"	"$refracttint[1]"
+		}		
+		"Subtract"
+		{
+			"srcvar1"	"$one"
+			"srcvar2"	"$temp"
+			"resultvar"	"$refracttint[2]"
+		}
+		"Multiply"
+		{
+			"srcvar1"	"$two"
+			"srcvar2"	"$thermoptic"
+			"resultvar"	"$temp"
+		}
+		"Add"
+		{
+			"srcvar1"	"$blurstart"
+			"srcvar2"	"$temp"
+			"resultvar"	"$bluramount"
+		}								
+	}
+}


### PR DESCRIPTION
The original cloak vmt first writes to the red channel of the cloak tint, then modifies the temp value slightly before writing to the green and blue channels, giving the cloak a cyan tint. This tint is visible in the original when players move close to you, but for players standing still close to you, and players moving and standing still a distance away, as well as the player's own view model, this tint isn't present

I haven't yet worked out a good way of controlling this tint so it only appears for cloaked players moving close to you, for now I figured it would be easier to modify the material so the red channel always receives the same value as the green and blue channels.

The difference between this and the original is the first Subtract proxy is run after the second Multiply proxy instead of before. This also renders the first Multiply proxy and the const $mod useless for now, and as such they have been commented out