### PR TITLE
Rabbitfrog engines should not be VertexLitGeneric

### DIFF
--- a/neo/materials/models/props_vehicles/rabbitfrog_engine_anim.vmt
+++ b/neo/materials/models/props_vehicles/rabbitfrog_engine_anim.vmt
@@ -1,4 +1,4 @@
-"VertexLitGeneric"
+"UnlitGeneric"
 {
 	"$baseTexture" "\models\props_vehicles\rabbitfrog_engine_anim"
 	"$surfaceprop" "metal"
@@ -6,8 +6,6 @@
 	"$nocull" 1
 	"$additive" 1
 	"$model" 1
-	"$vertexcolor" 1
-	"$vertexalpha" 1
 	"Proxies"
 	{
 		"TextureScroll"

--- a/neo/materials/models/props_vehicles/rabbitfrog_engine_anim2.vmt
+++ b/neo/materials/models/props_vehicles/rabbitfrog_engine_anim2.vmt
@@ -1,4 +1,4 @@
-"VertexLitGeneric"
+"UnlitGeneric"
 {
 	"$baseTexture" "\models\props_vehicles\rabbitfrog_engine_anim2"
 	"$surfaceprop" "metal"
@@ -6,8 +6,6 @@
 	"$nocull" 1
 	"$additive" 1
 	"$model" 1
-	"$vertexcolor" 1
-	"$vertexalpha" 1
 	"Proxies"
 	{
 		"TextureScroll"

--- a/neo/materials/models/props_vehicles/rabbitfrog_engine_anim3.vmt
+++ b/neo/materials/models/props_vehicles/rabbitfrog_engine_anim3.vmt
@@ -1,4 +1,4 @@
-"VertexLitGeneric"
+"UnlitGeneric"
 {
 	"$baseTexture" "\models\props_vehicles\rabbitfrog_engine_anim3"
 	"$surfaceprop" "metal"
@@ -6,8 +6,6 @@
 	"$nocull" 1
 	"$additive" 1
 	"$model" 1
-	"$vertexcolor" 1
-	"$vertexalpha" 1
 	"Proxies"
 	{
 		"TextureScroll"


### PR DESCRIPTION
Reverting error fix and instead removing the offending parameters which were not necessary