### PR TITLE
Fix alley chapter bg non-widescreen texture

### DIFF
--- a/neo/materials/console/background_alley.vmt
+++ b/neo/materials/console/background_alley.vmt
@@ -1,6 +1,6 @@
 UnlitGeneric
 {
-	$basetexture "console/background_alley_widescreen"
+	$basetexture "console/background_alley"
 	$vertexcolor 1
 	$vertexalpha 1
 	$ignorez 1


### PR DESCRIPTION
Fix the non-widescreen version of the background_alley main menu chapter background using the widescreen version of the background texture.